### PR TITLE
Set affinitize based on if hyper threading is ON/OFF

### DIFF
--- a/PrimeNumbers/PrimeNumber_join.cpp
+++ b/PrimeNumbers/PrimeNumber_join.cpp
@@ -761,11 +761,6 @@ public:
     }
 };
 
-void printInfo()
-{
-
-}
-
 int main(int argc, char** argv)
 {
     PrimeNumbers p(argc, argv);


### PR DESCRIPTION
Programmatically determine if hyper threading is enabled or not and depending on that set the affinitize. This removes the `--affi` and `--ht` flag.