### PR TITLE
Add support for umwait in PrimeNumbers

### DIFF
--- a/PrimeNumbers/PrimeNumber_join.cpp
+++ b/PrimeNumbers/PrimeNumber_join.cpp
@@ -416,7 +416,7 @@ private:
         {
             if ((join_type < 3) || (join_type > 10))
             {
-                printf("Warning: '--mwaitx_cycle_count' is specified, but value will not be used for 'pause' wait type.\n");
+                printf("Warning: '--wait_count' is specified, but value will not be used for 'pause' wait type.\n");
             }
             else
             {
@@ -427,7 +427,7 @@ private:
         {
             if ((join_type >= 3) && (join_type <= 10))
             {
-                printf("Warning: '--mwaitx_cycle_count' is needed when join_type is related to mwaitx/umwait.\n");
+                printf("Warning: '--wait_count' is needed when join_type is related to mwaitx/umwait.\n");
                 PrintUsageAndExit();
             }
         }
@@ -508,6 +508,7 @@ private:
         printf("--thread_priority [0|1]: If 1 (default), create threads with high priority otherwise create them with normal priority.\n\n");
         printf("--spin_count <N>: If specified, the number of iterations to spin before going to hardwait. Default= 128000.\n\n");
         printf("--wait_count <N>: WAIT value to be used in mwaitx()/umwait(). Required if --join_type is between [3-10]. For mwaitx, it is cycles and for umwait, it is timestamp.\n\n");
+        printf("--umwait_power_state [0|1]: If 0, execute umwait in high power savings/slower wake-up; if 1, low power savings/fast wake-up.\n");
         printf("--affi <AFF_TYPE>: Affinitization to conduct. <AFF_TYPE> can be:\n");
         printf("  0= affinity (default)\n");
         printf("  1= affinity physical core\n");

--- a/PrimeNumbers/t_join.h
+++ b/PrimeNumbers/t_join.h
@@ -421,3 +421,93 @@ public:
     /// <returns>Total spin iterations performed.</returns>
     virtual ulong join(int inputIndex, int threadId, bool* wasHardWait, unsigned __int64* spinLoopStartTime, unsigned __int64* spinLoopStopTime);
 };
+
+//------
+
+class t_join_umwait_noloop : public t_join
+{
+private:
+    const int umwait_cycles;
+    const bool is_low_power;
+
+public:
+    t_join_umwait_noloop(int numThreads, int umwait_timeout, bool low_power) : t_join(numThreads), umwait_cycles(umwait_timeout), is_low_power(low_power)
+    {
+    }
+
+    /// <summary>
+    /// Use umonitor/umwait without doing spin-loop. If the timeout
+    /// expires and the color hasn't change, it will go to hard-wait.
+    /// </summary>
+    /// <param name="inputIndex">index for which join is performed.</param>
+    /// <param name="threadId">Thread id</param>
+    /// <param name="wasHardWait">If there was hardwait needed</param>
+    /// <returns>Total spin iterations performed.</returns>
+    virtual ulong join(int inputIndex, int threadId, bool* wasHardWait, unsigned __int64* spinLoopStartTime, unsigned __int64* spinLoopStopTime);
+};
+
+class t_join_umwait_loop : public t_join
+{
+private:
+    const int umwait_cycles;
+    const bool is_low_power;
+
+public:
+    t_join_umwait_loop(int numThreads, int umwait_timeout, bool low_power) : t_join(numThreads), umwait_cycles(umwait_timeout), is_low_power(low_power)
+    {
+    }
+
+    /// <summary>
+    /// Use umonitor/umwait inside spin-loop. If the timeout
+    /// expires and the color hasn't change, it will go to hard-wait.
+    /// </summary>
+    /// <param name="inputIndex">index for which join is performed.</param>
+    /// <param name="threadId">Thread id</param>
+    /// <param name="wasHardWait">If there was hardwait needed</param>
+    /// <returns>Total spin iterations performed.</returns>
+    virtual ulong join(int inputIndex, int threadId, bool* wasHardWait, unsigned __int64* spinLoopStartTime, unsigned __int64* spinLoopStopTime);
+};
+
+class t_join_umwait_loop_soft_wait_only : public t_join
+{
+private:
+    const int umwait_cycles;
+    const bool is_low_power;
+
+public:
+    t_join_umwait_loop_soft_wait_only(int numThreads, int umwait_timeout, bool low_power) : t_join(numThreads), umwait_cycles(umwait_timeout), is_low_power(low_power)
+    {
+    }
+
+    /// <summary>
+    /// Only uses spin-loop for color change, with "umwait" inside every iteration.
+    /// No hard-wait is done.
+    /// </summary>
+    /// <param name="inputIndex">index for which join is performed.</param>
+    /// <param name="threadId">Thread id</param>
+    /// <param name="wasHardWait">If there was hardwait needed</param>
+    /// <returns>Total spin iterations performed.</returns>
+    virtual ulong join(int inputIndex, int threadId, bool* wasHardWait, unsigned __int64* spinLoopStartTime, unsigned __int64* spinLoopStopTime);
+};
+
+class t_join_umwait_noloop_soft_wait_only : public t_join
+{
+private:
+    const int umwait_cycles;
+    const bool is_low_power;
+
+public:
+    t_join_umwait_noloop_soft_wait_only(int numThreads, int umwait_timeout, bool low_power) : t_join(numThreads), umwait_cycles(umwait_timeout), is_low_power(low_power)
+    {
+    }
+
+    /// <summary>
+    /// Only uses "umwait" with TIMEOUT inside every iteration.
+    /// No hard-wait is done.
+    /// </summary>
+    /// <param name="inputIndex">index for which join is performed.</param>
+    /// <param name="threadId">Thread id</param>
+    /// <param name="wasHardWait">If there was hardwait needed</param>
+    /// <returns>Total spin iterations performed.</returns>
+    virtual ulong join(int inputIndex, int threadId, bool* wasHardWait, unsigned __int64* spinLoopStartTime, unsigned __int64* spinLoopStopTime);
+};

--- a/PrimeNumbersTrend/Program.cs
+++ b/PrimeNumbersTrend/Program.cs
@@ -108,7 +108,7 @@ public class PrimeNumbersTrend
         public int Ht { get; }
 
         public string CommandLine
-            => $"--input_count {Input} --complexity {Complexity} --thread_count {Thread} --mwaitx_cycle_count {Timeout} --affi {Affinitize} --join_type {JoinType} --ht {Ht}";
+            => $"--input_count {Input} --complexity {Complexity} --thread_count {Thread} --wait_count {Timeout} --affi {Affinitize} --join_type {JoinType} --ht {Ht}";
     }
 
 
@@ -160,7 +160,7 @@ public class PrimeNumbersTrend
                 results.Append("|Cycles spin per thread");
                 results.Append("|Elapsed time");
                 results.Append("|Elapsed cycles");
-                results.Append("|MWaitx Cycles");
+                results.Append("|Timeout");
                 results.AppendLine();
                 int columns = results.ToString().Count(c => c == '|');
                 for (int col = 0; col <= columns; col++) 

--- a/PrimeNumbersTrend/README.md
+++ b/PrimeNumbersTrend/README.md
@@ -68,7 +68,7 @@ Total cycles spinning | Total Spin Loop Time
 Cycles spin per thread| Total Spin Loop Time / Thread_Count
 Elapsed time| Total time in microseconds taken to process entire input.
 Elapsed cycles| Elapsed Ticks
-MWaitx Cycles | MWaitx Cycles
+Timeout | Either MwaitX CPU cycles or UMWAIT timestamp at which these instructions timeout.
 
 Note:
 - `*_per_number` shows metrics to process each number.


### PR DESCRIPTION
- Added support for 4 join_types related to Intel's `umwait` instruction
- Also renamed the `mwait_cycles_count` to `wait_units` that can be applicable for both mwaitx/umwait.