### PR TITLE
Add formula to map affinity to uprof

### DIFF
--- a/testCPUID-all/testCPUID.cpp
+++ b/testCPUID-all/testCPUID.cpp
@@ -438,6 +438,11 @@ void SetThreadAffinity(HANDLE tHandle, int procNum)
 * On the contrary, below calculation could have been reverse mapped, i.e. we could have treated the
 * procNum as the one we want to see on uprof and recalculated the numbers to be set in GROUP_AFFINITY
 * struct.
+*
+* To conclude, these numbers are HARDCODED for a particular machine and uprof uses numa nodes to do
+* its core indexing so in this case group#0 contains numa node 0, 2, 4, etc, instead of node 0, 1, 2, etc.
+* And each numa node has 8 cores in this case. so in cpu group terms, core#8 in group#0 actually is
+* considered as core#16 by uprof, because it belongs to numa node#2.
 * -----------------------
 * procNum         uprof
 * -----------------------

--- a/testCPUID-all/testCPUID.cpp
+++ b/testCPUID-all/testCPUID.cpp
@@ -377,27 +377,89 @@ void SetThreadAffinity(HANDLE tHandle, int procNum)
     ga.Reserved[2] = 0;
     ga.Mask = (size_t)1 << (procNum % 64);
 
-    /*
-procNum         uprof
------------------------
-0-7             0-7      Group 0
-8-15            16-23
-16-23           32-39
-24-31           48-55
-32-39           64-71
-40-47           80-87
-48-55           96-103
-56-63           112-119
+/**********************************************************************************
+* For high core machines (like the one we are experimenting with), the hierarchy
+* looks like below:
+* /----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------\
+* | Machine (242GB total)                                                                                                                                                                                                |
+* |                                                                                                                                                                                                                      |
+* | /------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------\ |
+* | | Group #0                                                                                                                                                                                                         | |
+* | |                                                                                                                                                                                                                  | |
+* | | /--------------------------------------------------------------\  /--------------------------------------------------------------\              /--------------------------------------------------------------\ | |
+* | | | NUMANode P#0 (13GB)                                          |  | NUMANode P#2 (15GB)                                          |  ++  ++  ++  | NUMANode P#16(14GB)                                          | | |
+* | | \--------------------------------------------------------------/  \--------------------------------------------------------------/              \--------------------------------------------------------------/ | |
+* | |                                                                                                                                      8x total                                                                    | |
+* | |                                                                                                                                                                                                                  | |
+* | |                                                                                                                                                                                                                  | |
+* | | /--------------\  /--------------\              /--------------\  /--------------\  /--------------\              /--------------\              /--------------\  /--------------\              /--------------\ | |
+* | | | Core         |  | Core         |  ++  ++  ++  | Core         |  | Core         |  | Core         |  ++  ++  ++  | Core         |              | Core         |  | Core         |  ++  ++  ++  | Core         | | |
+* | | |              |  |              |              |              |  |              |  |              |              |              |              |              |  |              |              |              | | |
+* | | | /----------\ |  | /----------\ |   8x total   | /----------\ |  | /----------\ |  | /----------\ |   8x total   | /----------\ |              | /----------\ |  | /----------\ |   8x total   | /----------\ | | |
+* | | | |  PU P#0  | |  | |  PU P#1  | |              | |  PU P#7  | |  | |  PU P#8  | |  | |  PU P#9  | |              | | PU P#15  | |              | | PU P#88  | |  | | PU P#89  | |              | | PU P#95  | | | |
+* | | | \----------/ |  | \----------/ |              | \----------/ |  | \----------/ |  | \----------/ |              | \----------/ |              | \----------/ |  | \----------/ |              | \----------/ | | |
+* | | \--------------/  \--------------/              \--------------/  \--------------/  \--------------/              \--------------/              \--------------/  \--------------/              \--------------/ | |
+* | \------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------/ |
+* |                                                                                                                                                                                                                      |
+* | /------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------\ |
+* | | Group #1                                                                                                                                                                                                    | |
+* | |                                                                                                                                                                                                                  | |
+* | |        ...............
+* | \------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------/ |
+* \----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------/
+*
+* A machine has packages (usually 2, but may be higher) and they are sometimes referred
+* to as groups. Each group has various NUMA nodes. The presence of NUMA nodes are not
+* necessarily sequential. In above example, all the even numbered NUMA nodes are present
+* in group #0 and odd-numbered are present in group #1. To find which NUMA nodes are present
+* in which group, follow the instructions:
+* Task Manager -> Detail -> right-click on any non-admin process -> Set affinity
+* If the machine is multi-package or multi-group NUMA aware machine, you would see a drop-down
+* to select group and the corresponding NUMA nodes will show up. Each NUMA node contains the 
+* cores (typically 8 cores).
+*           Group 0
+*               NUMA 0      0 ~ 7
+*               NUMA 2      16 ~ 23
+*               NUMA 4      32 ~ 39
+*               .....
+*           Group 1
+*               NUMA 1      8 ~ 16
+*               NUMA 3      24 ~ 31
+*               .....
+*
+* With that background, lets see how below table was calculated. For simplicity, we have turned
+* off hyper-threading OFF.
+*
+* When affinitizing procNum 0~7, they would map 1-to-1 with core 0~7. Next, procNum 8~16 is mapped
+* to the cores in Group 0, as per (procNum >> 6) calculation above. But those maps to core 16~23
+* as seen in example above. Likewise, when procNum 64~71 is passed, those are the first set of 
+* cores we are trying to affinitize in Group# 1 and hence maps to core 8~16.
+*
+* On the contrary, below calculation could have been reverse mapped, i.e. we could have treated the
+* procNum as the one we want to see on uprof and recalculated the numbers to be set in GROUP_AFFINITY
+* struct.
+* -----------------------
+* procNum         uprof
+* -----------------------
+* 0-7             0-7      Group 0
+* 8-15            16-23
+* 16-23           32-39
+* 24-31           48-55
+* 32-39           64-71
+* 40-47           80-87
+* 48-55           96-103
+* 56-63           112-119
 
-64-71           8-15    Group 1
-72-79           24-31
-80-87           40-47
-88-95           56-63
-96-103          72-79
-104-111         88-95
-112-119         104-111
-120-127         120-127
-    */
+* 64-71           8-15    Group 1
+* 72-79           24-31
+* 80-87           40-47
+* 88-95           56-63
+* 96-103          72-79
+* 104-111         88-95
+* 112-119         104-111
+* 120-127         120-127
+*
+**********************************************************************************/
 
     //for (procNum = 0; procNum < 128; procNum++)
     {
@@ -459,7 +521,7 @@ void experiment(LPTHREAD_START_ROUTINE proc)
     ResumeThread(g_hThread);
 
     // sleep for 10s
-    Sleep((DWORD)20 * 1000);
+    Sleep((DWORD)10 * 1000);
     g_aligned_global_location.loc = 5;
 
     printf("end...\n");


### PR DESCRIPTION
Here we see, if we use `YIELD_PROCESSOR`, we can see worker core `48` consumes power:

<img width="1873" alt="image" src="https://user-images.githubusercontent.com/12488060/224221102-ae475447-57e2-4b14-a6c4-781b59fd13f5.png">

`mwaitx`, we can see the power consumption drops.

<img width="1859" alt="MicrosoftTeams-image (3)" src="https://user-images.githubusercontent.com/12488060/224221148-4e80612f-b9b7-4287-a701-e33ce51dc6c8.png">
